### PR TITLE
Defer CLI tree construction until runtime

### DIFF
--- a/src/toolrack/cli.py
+++ b/src/toolrack/cli.py
@@ -695,15 +695,48 @@ def _build_cli_tree(entries: list[dict], aliases: dict[str, str]) -> None:
             cli.add_command(cmd)
 
 
-@click.group()
+_STATIC_COMMANDS = {"core"}
+_DYNAMIC_CLI_SIGNATURE: str | None = None
+
+
+def _clear_dynamic_cli_tree() -> None:
+    for name in list(cli.commands.keys()):
+        if name not in _STATIC_COMMANDS:
+            cli.commands.pop(name)
+
+
+def _ensure_cli_tree() -> None:
+    global _DYNAMIC_CLI_SIGNATURE
+
+    repo = _current_repo()
+    registry = _read_registry(repo)
+    signature = _cache_signature(registry, repo)
+    if _DYNAMIC_CLI_SIGNATURE == signature:
+        return
+
+    _clear_dynamic_cli_tree()
+    aliases = _load_aliases(repo)
+    _build_cli_tree(_load_cli_entries(registry, aliases, repo), aliases)
+    _DYNAMIC_CLI_SIGNATURE = signature
+
+
+class RuntimeCLIGroup(click.Group):
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        if cmd_name not in self.commands:
+            _ensure_cli_tree()
+        return super().get_command(ctx, cmd_name)
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        _ensure_cli_tree()
+        return super().list_commands(ctx)
+
+
+@click.group(cls=RuntimeCLIGroup)
 @click.version_option(prog_name=CLI_NAME)
 def cli():
     """Typed dispatcher for a user-owned scripts repository."""
 
 
-_INITIAL_REPO = _current_repo()
-_INITIAL_ALIASES = _load_aliases(_INITIAL_REPO)
-_build_cli_tree(_load_cli_entries(_read_registry(_INITIAL_REPO), _INITIAL_ALIASES, _INITIAL_REPO), _INITIAL_ALIASES)
 # TODO(#10): Avoid import-time CLI tree construction. It speeds up the "single file
 # script" model, but it also means import has side effects and front-loads work
 # even for commands that only need core maintenance operations.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,8 @@ Covers:
 import json
 import ntpath
 import os
+import subprocess
+import sys
 import pytest
 
 import toolrack.cli as cli
@@ -556,12 +558,52 @@ def _register_in_tmp(rel_script_path: str):
 
 
 def _reload_tree():
-    builtins = {"core"}
-    for name in list(cli.cli.commands.keys()):
-        if name not in builtins:
-            cli.cli.commands.pop(name)
-    aliases = _load_aliases()
-    _build_cli_tree(cli._load_cli_entries(_read_registry(), aliases), aliases)
+    cli._DYNAMIC_CLI_SIGNATURE = None
+    cli._clear_dynamic_cli_tree()
+    cli._ensure_cli_tree()
+
+
+class TestLazySetup:
+
+    def test_import_does_not_load_aliases_or_build_dynamic_commands(self, repo):
+        repo["registry"].write_text("scripts/github/check_review.py\n", encoding="utf-8")
+        repo["aliases"].write_text("[groups]\nfoo = bar\nbaz = bar\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.path.dirname(os.path.dirname(cli.__file__))
+        env["TOOLRACK_REPO_ROOT"] = str(repo["root"])
+        env["TOOLRACK_SCRIPTS_ROOT"] = str(repo["scripts"])
+        env["TOOLRACK_REGISTRY_FILE"] = str(repo["registry"])
+        env["TOOLRACK_CACHE_FILE"] = str(repo["cache"])
+        env["TOOLRACK_ALIASES_FILE"] = str(repo["aliases"])
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import toolrack.cli"],
+            cwd=repo["root"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+    def test_core_command_does_not_require_dynamic_tree(self, repo, runner):
+        repo["aliases"].write_text("[groups]\nfoo = bar\nbaz = bar\n", encoding="utf-8")
+        result = runner.invoke(cli.cli, ["core", "list"])
+        assert result.exit_code == 0, result.output
+        assert "No scripts registered" in result.output
+
+    def test_dynamic_command_lookup_builds_tree_on_demand(
+            self, repo, runner, make_script, make_sidecar):
+        make_script("github/check_review.py")
+        make_sidecar("github/check_review.py", {"description": "Check a review."})
+        _register_in_tmp("github/check_review.py")
+        cli._clear_dynamic_cli_tree()
+        cli._DYNAMIC_CLI_SIGNATURE = None
+
+        result = runner.invoke(cli.cli, ["github", "check-review", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Check a review" in result.output
 
 
 class TestCommandTree:


### PR DESCRIPTION
Closes #10.

## Summary
- replace import-time CLI tree construction with a lazy RuntimeCLIGroup
- build dynamic commands only when command lookup or top-level help/completion needs them
- keep core commands available without requiring registry or alias loading
- add tests covering lightweight import, core command behavior with broken aliases, and on-demand dynamic command loading

## Testing
- py -3.14 -m pytest tests/test_cli.py
- py -3.14 -m pytest