### PR TITLE
Return dynamic command exit codes without sys.exit

### DIFF
--- a/src/toolrack/cli.py
+++ b/src/toolrack/cli.py
@@ -524,7 +524,6 @@ def _click_param(spec: CommandArgSpec):
             type=click_type,
             nargs=-1 if spec.variadic else 1,
         )
-
     flag_name = spec.option or f"--{spec.name.replace('_', '-')}"
     if spec.flag:
         return click.Option([flag_name], is_flag=True, default=False, help=spec.help)
@@ -539,39 +538,42 @@ def _click_param(spec: CommandArgSpec):
     )
 
 
+def _run_dynamic_command(spec: CommandSpec, kwargs: dict) -> int:
+    """Execute a generated command and return the subprocess exit status."""
+    bash_exe = spec.interpreter[0] if spec.interpreter else ""
+    exec_path = (
+        _to_bash_path(spec.script_path, bash_exe)
+        if bash_exe == "bash" or bash_exe.endswith("bash.exe")
+        else spec.script_path
+    )
+    cmd = list(spec.interpreter) + [exec_path]
+    for arg_spec in spec.args:
+        value = kwargs[arg_spec.name]
+        flag_name = arg_spec.option or f"--{arg_spec.name.replace('_', '-')}"
+
+        if value is None or value == () or value is False:
+            continue
+        if arg_spec.positional:
+            if arg_spec.variadic:
+                for item in value:
+                    cmd.append(str(item))
+            else:
+                cmd.append(str(value))
+        elif arg_spec.flag:
+            cmd.append(flag_name)
+        elif arg_spec.multiple:
+            for item in value:
+                cmd.extend([flag_name, str(item)])
+        else:
+            cmd.extend([flag_name, str(value)])
+
+    result = subprocess.run(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+    return result.returncode
+
+
 def _command_callback(spec: CommandSpec):
     def callback(**kwargs):
-        # TODO(#7): Return subprocess exit codes instead of calling sys.exit from
-        # nested callbacks. This works for the current CLI-only model, but it
-        # makes embedding or reusing the dispatcher from Python awkward.
-        bash_exe = spec.interpreter[0] if spec.interpreter else ""
-        exec_path = (
-            _to_bash_path(spec.script_path, bash_exe)
-            if bash_exe == "bash" or bash_exe.endswith("bash.exe")
-            else spec.script_path
-        )
-        cmd = list(spec.interpreter) + [exec_path]
-        for arg_spec in spec.args:
-            value = kwargs[arg_spec.name]
-            flag_name = arg_spec.option or f"--{arg_spec.name.replace('_', '-')}"
-
-            if value is None or value == () or value is False:
-                continue
-            if arg_spec.positional:
-                if arg_spec.variadic:
-                    cmd.extend(str(item) for item in value)
-                else:
-                    cmd.append(str(value))
-            elif arg_spec.flag:
-                cmd.append(flag_name)
-            elif arg_spec.multiple:
-                for item in value:
-                    cmd.extend([flag_name, str(item)])
-            else:
-                cmd.extend([flag_name, str(value)])
-
-        result = subprocess.run(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
-        sys.exit(result.returncode)
+        return _run_dynamic_command(spec, kwargs)
 
     return callback
 
@@ -786,6 +788,11 @@ def cli():
     """Typed dispatcher for a user-owned scripts repository."""
 
 
+@cli.result_callback()
+def _propagate_command_exit_status(result, **_kwargs):
+    if type(result) is int:
+        raise click.exceptions.Exit(result)
+    return result
 # TODO(#10): Avoid import-time CLI tree construction. It speeds up the "single file
 # script" model, but it also means import has side effects and front-loads work
 # even for commands that only need core maintenance operations.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from toolrack.cli import (
     _generate_sidecar,
     _validate_sidecar,
     _load_aliases,
+    _make_command,
     _build_cli_tree,
     _read_cache,
     _write_cache,
@@ -933,6 +934,51 @@ class TestCommandTree:
         _register_in_tmp("github/check_review.py")
         (repo["scripts"] / "github" / "check_review.py").unlink()
         _reload_tree()  # no exception
+
+    def test_generated_command_callback_returns_subprocess_exit_code(
+            self, repo, make_script, make_sidecar, monkeypatch):
+        script_path = make_script("github/check_review.py")
+        sidecar = {
+            "description": "Check a review.",
+            "args": [{"name": "pr", "required": True, "type": "int"}],
+        }
+        make_sidecar("github/check_review.py", sidecar)
+        observed = {}
+
+        class FakeResult:
+            returncode = 7
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None):
+            observed["cmd"] = cmd
+            observed["stdin"] = stdin
+            observed["stdout"] = stdout
+            observed["stderr"] = stderr
+            return FakeResult()
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        command = _make_command(script_path, "check-review", sidecar)
+
+        result = command.callback(pr=123)
+
+        assert result == 7
+        assert observed["cmd"][0] == os.fspath(cli.sys.executable)
+        assert observed["cmd"][1] == script_path
+        assert observed["cmd"][2:] == ["--pr", "123"]
+
+    def test_dynamic_command_still_exits_with_subprocess_status(
+            self, repo, runner, make_script, make_sidecar, monkeypatch):
+        make_script("github/check_review.py")
+        make_sidecar("github/check_review.py", {"description": "Check a review."})
+        _register_in_tmp("github/check_review.py")
+        _reload_tree()
+
+        class FakeResult:
+            returncode = 7
+
+        monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: FakeResult())
+        result = runner.invoke(cli.cli, ["github", "check-review"])
+
+        assert result.exit_code == 7
 
 
 class TestDeploymentConfig:


### PR DESCRIPTION
## Summary
- extract dynamic command execution into a helper that returns the subprocess exit status
- have generated command callbacks return that status instead of calling sys.exit()
- propagate integer command results back to the shell from the top-level Click group
- add tests covering direct callback reuse and normal CLI exit-code propagation

Closes #7.

## Testing
- python -m pytest
