### PR TITLE
Isolate shell path translation behind a shell adapter layer

### DIFF
--- a/src/toolrack/cli.py
+++ b/src/toolrack/cli.py
@@ -158,6 +158,82 @@ class CommandSpec:
     epilog: str
 
 
+class ShellAdapter:
+    def resolve_bash_exe(self) -> str:
+        return "bash"
+
+    def should_translate_bash_script_path(self, bash_exe: str) -> bool:
+        return False
+
+    def to_bash_path(self, script_path: str, bash_exe: str = "") -> str:
+        return script_path
+
+
+class WindowsShellAdapter(ShellAdapter):
+    def resolve_bash_exe(self) -> str:
+        cygwin_bash = r"C:\cygwin64\bin\bash.exe"
+        git_bash = r"C:\Program Files\Git\bin\bash.exe"
+
+        if not os.environ.get("MSYSTEM"):
+            path_dirs = os.environ.get("PATH", "").split(os.pathsep)
+            cygwin_bin = r"C:\cygwin64\bin"
+            gitbash_bin = r"C:\Program Files\Git\bin"
+
+            def _norm(value: str) -> str:
+                return os.path.normcase(os.path.normpath(value))
+
+            normed = [_norm(entry) for entry in path_dirs]
+            cygwin_idx = next((idx for idx, entry in enumerate(normed) if entry == _norm(cygwin_bin)), 999)
+            gitbash_idx = next((idx for idx, entry in enumerate(normed) if entry == _norm(gitbash_bin)), 999)
+            if cygwin_idx < gitbash_idx and os.path.isfile(cygwin_bash):
+                return cygwin_bash
+
+        if os.environ.get("MSYSTEM") and os.path.isfile(git_bash):
+            return git_bash
+
+        return "bash"
+
+    def should_translate_bash_script_path(self, bash_exe: str) -> bool:
+        return bash_exe == "bash" or bash_exe.endswith("bash.exe")
+
+    def to_bash_path(self, script_path: str, bash_exe: str = "") -> str:
+        cygpath_candidates: list[str] = []
+        if bash_exe:
+            bash_dir = os.path.dirname(os.path.abspath(bash_exe))
+            same_dir = os.path.join(bash_dir, "cygpath.exe")
+            parent_usr_bin = os.path.join(os.path.dirname(bash_dir), "usr", "bin", "cygpath.exe")
+            for candidate in (same_dir, parent_usr_bin):
+                if os.path.isfile(candidate):
+                    cygpath_candidates.append(candidate)
+        cygpath_candidates.append("cygpath")
+
+        for cygpath_exe in cygpath_candidates:
+            try:
+                result = subprocess.run(
+                    [cygpath_exe, "-u", script_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    return result.stdout.strip()
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+
+        path = script_path.replace("\\", "/")
+        if len(path) >= 2 and path[1] == ":":
+            path = "/" + path[0].lower() + path[2:]
+        return path
+
+
+_WINDOWS_SHELL_ADAPTER = WindowsShellAdapter()
+_DEFAULT_SHELL_ADAPTER = ShellAdapter()
+
+
+def _shell_adapter() -> ShellAdapter:
+    return _WINDOWS_SHELL_ADAPTER if _is_windows() else _DEFAULT_SHELL_ADAPTER
+
+
 def _current_repo() -> RepositoryContext:
     return RepositoryContext(
         repo_root=REPO_ROOT,
@@ -368,66 +444,11 @@ def _validate_sidecar(sidecar: dict, script_path: str) -> None:
 
 
 def _to_bash_path(windows_path: str, bash_exe: str = "") -> str:
-    # TODO(#5): Isolate shell/path translation behind a shell adapter layer.
-    # Windows, Git Bash, and Cygwin compatibility logic is mixed into the core
-    # dispatcher, which makes the module harder to reason about than it should be.
-    if not _is_windows():
-        return windows_path
-
-    cygpath_candidates: list[str] = []
-    if bash_exe:
-        bash_dir = os.path.dirname(os.path.abspath(bash_exe))
-        same_dir = os.path.join(bash_dir, "cygpath.exe")
-        parent_usr_bin = os.path.join(os.path.dirname(bash_dir), "usr", "bin", "cygpath.exe")
-        for candidate in (same_dir, parent_usr_bin):
-            if os.path.isfile(candidate):
-                cygpath_candidates.append(candidate)
-    cygpath_candidates.append("cygpath")
-
-    for cygpath_exe in cygpath_candidates:
-        try:
-            result = subprocess.run(
-                [cygpath_exe, "-u", windows_path],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                return result.stdout.strip()
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            continue
-
-    path = windows_path.replace("\\", "/")
-    if len(path) >= 2 and path[1] == ":":
-        path = "/" + path[0].lower() + path[2:]
-    return path
+    return _shell_adapter().to_bash_path(windows_path, bash_exe)
 
 
 def _resolve_bash_exe() -> str:
-    if not _is_windows():
-        return "bash"
-
-    cygwin_bash = r"C:\cygwin64\bin\bash.exe"
-    git_bash = r"C:\Program Files\Git\bin\bash.exe"
-
-    if not os.environ.get("MSYSTEM"):
-        path_dirs = os.environ.get("PATH", "").split(os.pathsep)
-        cygwin_bin = r"C:\cygwin64\bin"
-        gitbash_bin = r"C:\Program Files\Git\bin"
-
-        def _norm(value: str) -> str:
-            return os.path.normcase(os.path.normpath(value))
-
-        normed = [_norm(entry) for entry in path_dirs]
-        cygwin_idx = next((idx for idx, entry in enumerate(normed) if entry == _norm(cygwin_bin)), 999)
-        gitbash_idx = next((idx for idx, entry in enumerate(normed) if entry == _norm(gitbash_bin)), 999)
-        if cygwin_idx < gitbash_idx and os.path.isfile(cygwin_bash):
-            return cygwin_bash
-
-    if os.environ.get("MSYSTEM") and os.path.isfile(git_bash):
-        return git_bash
-
-    return "bash"
+    return _shell_adapter().resolve_bash_exe()
 
 
 def _interpreter(script_path: str) -> list[str]:
@@ -435,7 +456,7 @@ def _interpreter(script_path: str) -> list[str]:
     if ext == ".py":
         return [sys.executable]
     if ext in (".sh", ".bash"):
-        return [_resolve_bash_exe()]
+        return [_shell_adapter().resolve_bash_exe()]
     if ext == ".sql":
         return ["psql", "-f"]
     return []
@@ -540,10 +561,11 @@ def _click_param(spec: CommandArgSpec):
 
 def _run_dynamic_command(spec: CommandSpec, kwargs: dict) -> int:
     """Execute a generated command and return the subprocess exit status."""
+    adapter = _shell_adapter()
     bash_exe = spec.interpreter[0] if spec.interpreter else ""
     exec_path = (
-        _to_bash_path(spec.script_path, bash_exe)
-        if bash_exe == "bash" or bash_exe.endswith("bash.exe")
+        adapter.to_bash_path(spec.script_path, bash_exe)
+        if adapter.should_translate_bash_script_path(bash_exe)
         else spec.script_path
     )
     cmd = list(spec.interpreter) + [exec_path]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,95 @@ class TestEnvPathNormalization:
         assert result == _sample_windows_path("example", "tools", "scripts")
 
 
+class TestShellAdapters:
+
+    def test_resolve_bash_exe_delegates_to_shell_adapter(self, monkeypatch):
+        class FakeAdapter(cli.ShellAdapter):
+            def resolve_bash_exe(self) -> str:
+                return "custom-bash"
+
+        monkeypatch.setattr(cli, "_shell_adapter", lambda: FakeAdapter())
+        assert cli._resolve_bash_exe() == "custom-bash"
+
+    def test_to_bash_path_delegates_to_shell_adapter(self, monkeypatch):
+        class FakeAdapter(cli.ShellAdapter):
+            def to_bash_path(self, script_path: str, bash_exe: str = "") -> str:
+                return f"translated:{script_path}:{bash_exe}"
+
+        monkeypatch.setattr(cli, "_shell_adapter", lambda: FakeAdapter())
+        assert cli._to_bash_path("C:\\repo\\script.sh", "bash.exe") == "translated:C:\\repo\\script.sh:bash.exe"
+
+    def test_run_dynamic_command_uses_adapter_for_bash_path_translation(self, monkeypatch):
+        observed = {}
+
+        class FakeAdapter(cli.ShellAdapter):
+            def should_translate_bash_script_path(self, bash_exe: str) -> bool:
+                return bash_exe == "bash"
+
+            def to_bash_path(self, script_path: str, bash_exe: str = "") -> str:
+                observed["translated_from"] = (script_path, bash_exe)
+                return "/translated/script.sh"
+
+        class FakeResult:
+            returncode = 0
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None):
+            observed["cmd"] = cmd
+            return FakeResult()
+
+        monkeypatch.setattr(cli, "_shell_adapter", lambda: FakeAdapter())
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        spec = CommandSpec(
+            script_path=r"C:\repo\scripts\example.sh",
+            command_name="example",
+            interpreter=("bash",),
+            description="",
+            args=(),
+            env=(),
+            epilog="",
+        )
+
+        rc = cli._run_dynamic_command(spec, {})
+
+        assert rc == 0
+        assert observed["translated_from"] == (r"C:\repo\scripts\example.sh", "bash")
+        assert observed["cmd"] == ["bash", "/translated/script.sh"]
+
+    def test_run_dynamic_command_skips_translation_when_adapter_disables_it(self, monkeypatch):
+        observed = {}
+
+        class FakeAdapter(cli.ShellAdapter):
+            def should_translate_bash_script_path(self, bash_exe: str) -> bool:
+                return False
+
+            def to_bash_path(self, script_path: str, bash_exe: str = "") -> str:
+                raise AssertionError("should not be called")
+
+        class FakeResult:
+            returncode = 0
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None):
+            observed["cmd"] = cmd
+            return FakeResult()
+
+        monkeypatch.setattr(cli, "_shell_adapter", lambda: FakeAdapter())
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        spec = CommandSpec(
+            script_path=r"C:\repo\scripts\example.sh",
+            command_name="example",
+            interpreter=("not-bash",),
+            description="",
+            args=(),
+            env=(),
+            epilog="",
+        )
+
+        rc = cli._run_dynamic_command(spec, {})
+
+        assert rc == 0
+        assert observed["cmd"] == ["not-bash", r"C:\repo\scripts\example.sh"]
+
+
 class TestRepoRootDiscovery:
 
     def test_find_repo_root_prefers_registry_marker(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #5.

## Summary
- introduce a shell adapter boundary to encapsulate shell-specific behavior
- move Windows/Git Bash/Cygwin path translation and bash resolution into WindowsShellAdapter
- keep _to_bash_path() and _resolve_bash_exe() as compatibility wrappers that delegate to the adapter
- route dynamic command execution through adapter methods instead of embedding shell checks in core dispatch flow

## Tests
- python -m pytest tests/test_cli.py
- python -m pytest

Both commands pass locally.