### PR TITLE
Handle CRLF in Windows Bash by adding `-O igncr` when dispatching shell scripts

### DIFF
--- a/src/toolrack/cli.py
+++ b/src/toolrack/cli.py
@@ -546,7 +546,13 @@ def _run_dynamic_command(spec: CommandSpec, kwargs: dict) -> int:
         if bash_exe == "bash" or bash_exe.endswith("bash.exe")
         else spec.script_path
     )
-    cmd = list(spec.interpreter) + [exec_path]
+    cmd = list(spec.interpreter)
+    if _is_windows() and cmd and (cmd[0] == "bash" or cmd[0].endswith("bash.exe")):
+        # CRLF-checked-out shell scripts fail in Cygwin with:
+        #   set: pipefail\r: invalid option name
+        # Allow Windows Bash variants to ignore carriage returns.
+        cmd.extend(["-O", "igncr"])
+    cmd.append(exec_path)
     for arg_spec in spec.args:
         value = kwargs[arg_spec.name]
         flag_name = arg_spec.option or f"--{arg_spec.name.replace('_', '-')}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -965,6 +965,36 @@ class TestCommandTree:
         assert observed["cmd"][1] == script_path
         assert observed["cmd"][2:] == ["--pr", "123"]
 
+    def test_shell_command_enables_igncr_on_windows(
+            self, repo, make_script, make_sidecar, monkeypatch):
+        script_path = make_script("github/check_review.sh")
+        sidecar = {"description": "Check a review."}
+        make_sidecar("github/check_review.sh", sidecar)
+        observed = {}
+
+        class FakeResult:
+            returncode = 0
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None):
+            observed["cmd"] = cmd
+            return FakeResult()
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(cli, "_is_windows", lambda: True)
+        monkeypatch.setattr(cli, "_resolve_bash_exe", lambda: "C:\\cygwin64\\bin\\bash.exe")
+        monkeypatch.setattr(cli, "_to_bash_path", lambda script_path, bash_exe: "/cygdrive/c/repo/script.sh")
+        command = _make_command(script_path, "check-review", sidecar)
+
+        result = command.callback()
+
+        assert result == 0
+        assert observed["cmd"][:4] == [
+            "C:\\cygwin64\\bin\\bash.exe",
+            "-O",
+            "igncr",
+            "/cygdrive/c/repo/script.sh",
+        ]
+
     def test_dynamic_command_still_exits_with_subprocess_status(
             self, repo, runner, make_script, make_sidecar, monkeypatch):
         make_script("github/check_review.py")


### PR DESCRIPTION
### Motivation
- Cygwin/Git Bash can fail parsing CRLF-terminated shell scripts (e.g. `set: pipefail\r: invalid option name`) when toolrack dispatches `.sh` files on Windows. 
- The goal is to make Windows Bash variants tolerant of CRLF line endings without requiring every script to be normalized.

### Description
- Update `_run_dynamic_command` to detect Windows Bash invocations and insert `-O igncr` into the argv before the script path so Bash ignores carriage returns when running `*.sh`/`*.bash` scripts.
- This change only applies when `_is_windows()` is true and the resolved interpreter is a Bash executable (e.g. `bash` or endswith `bash.exe`).
- Add `test_shell_command_enables_igncr_on_windows` in `tests/test_cli.py` to assert the generated subprocess argv contains `-O` and `igncr` for a Windows Bash shell dispatch.

### Testing
- Ran `pytest` and the full unit test suite passed: `103 passed, 16 deselected`.
- The newly added unit test `test_shell_command_enables_igncr_on_windows` passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36d9ca6f08320a0bb962967f11ba8)